### PR TITLE
Fix: 2 Chip Select Line BMSDriver 

### DIFF
--- a/include/ACU_Constants.h
+++ b/include/ACU_Constants.h
@@ -28,7 +28,7 @@ namespace ACUConstants
     /* Task Times */
     constexpr uint32_t TICK_SM_PERIOD_US = 1000UL; // 1 000 us = 1000 Hz
     constexpr uint32_t TICK_SM_PRIORITY = 9;
-    constexpr uint32_t KICK_WATCHDOG_PERIOD_US = 80UL; // 100 us = 1 000 Hz | to compensate for delays, otherwise get 20ms watchdog periods->bad
+    constexpr uint32_t KICK_WATCHDOG_PERIOD_US = 100UL; // 100 us = 1 000 Hz | to compensate for delays, otherwise get 20ms watchdog periods->bad
     constexpr uint32_t WATCHDOG_PRIORITY = 1;
     constexpr uint32_t SAMPLE_BMS_PERIOD_US = 20000UL; // 20 000 us = 50 Hz
     constexpr uint32_t SAMPLE_BMS_PRIORITY = 2;

--- a/include/ACU_Constants.h
+++ b/include/ACU_Constants.h
@@ -32,7 +32,7 @@ namespace ACUConstants
     constexpr uint32_t WATCHDOG_PRIORITY = 1;
     constexpr uint32_t SAMPLE_BMS_PERIOD_US = 20000UL; // 20 000 us = 50 Hz
     constexpr uint32_t SAMPLE_BMS_PRIORITY = 2;
-    constexpr uint32_t EVAL_ACC_PERIOD_US = 10000UL; // 10 000 us = 100 Hz
+    constexpr uint32_t EVAL_ACC_PERIOD_US = 20000UL; // 20 000 us = 50 Hz
     constexpr uint32_t EVAL_ACC_PRIORITY = 10;
     constexpr uint32_t WRITE_CELL_BALANCE_PERIOD_US = 100000UL; // 100 000 us = 10 Hz
     constexpr uint32_t WRITE_CELL_BALANCE_PRIORITY = 6;

--- a/include/ACU_Constants.h
+++ b/include/ACU_Constants.h
@@ -14,11 +14,11 @@ namespace ACUConstants
     constexpr size_t NUM_CELL_TEMPS = 48;
     constexpr size_t NUM_CHIPS = 12;
     constexpr size_t NUM_BOARD_TEMPS = 12;
-    constexpr size_t NUM_CHIP_SELECTS = 1;
+    constexpr size_t NUM_CHIP_SELECTS = 2;
 
     // Initialize chip_select, chip_select_per_chip, and address
-    constexpr std::array<int, NUM_CHIP_SELECTS> CS = {10};
-    constexpr std::array<int, NUM_CHIPS> CS_PER_CHIP = {10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10};
+    constexpr std::array<int, NUM_CHIP_SELECTS> CS = {9, 10};
+    constexpr std::array<int, NUM_CHIPS> CS_PER_CHIP = {9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10};
     constexpr std::array<int, NUM_CHIPS> ADDR = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}; // only for addressable bms chips
 
     /* Interface Constants */
@@ -28,9 +28,9 @@ namespace ACUConstants
     /* Task Times */
     constexpr uint32_t TICK_SM_PERIOD_US = 1000UL; // 1 000 us = 1000 Hz
     constexpr uint32_t TICK_SM_PRIORITY = 9;
-    constexpr uint32_t KICK_WATCHDOG_PERIOD_US = 100UL; // 100 us = 1 000 Hz | to compensate for delays, otherwise get 20ms watchdog periods->bad
+    constexpr uint32_t KICK_WATCHDOG_PERIOD_US = 80UL; // 100 us = 1 000 Hz | to compensate for delays, otherwise get 20ms watchdog periods->bad
     constexpr uint32_t WATCHDOG_PRIORITY = 1;
-    constexpr uint32_t SAMPLE_BMS_PERIOD_US = 66666UL; // 66 666 us = 15Hz
+    constexpr uint32_t SAMPLE_BMS_PERIOD_US = 10000UL; // 66 666 us = 15Hz
     constexpr uint32_t SAMPLE_BMS_PRIORITY = 2;
     constexpr uint32_t EVAL_ACC_PERIOD_US = 10000UL; // 10 000 us = 100 Hz
     constexpr uint32_t EVAL_ACC_PRIORITY = 10;

--- a/include/ACU_Constants.h
+++ b/include/ACU_Constants.h
@@ -30,13 +30,13 @@ namespace ACUConstants
     constexpr uint32_t TICK_SM_PRIORITY = 9;
     constexpr uint32_t KICK_WATCHDOG_PERIOD_US = 80UL; // 100 us = 1 000 Hz | to compensate for delays, otherwise get 20ms watchdog periods->bad
     constexpr uint32_t WATCHDOG_PRIORITY = 1;
-    constexpr uint32_t SAMPLE_BMS_PERIOD_US = 10000UL; // 66 666 us = 15Hz
+    constexpr uint32_t SAMPLE_BMS_PERIOD_US = 20000UL; // 20 000 us = 50 Hz
     constexpr uint32_t SAMPLE_BMS_PRIORITY = 2;
     constexpr uint32_t EVAL_ACC_PERIOD_US = 10000UL; // 10 000 us = 100 Hz
     constexpr uint32_t EVAL_ACC_PRIORITY = 10;
     constexpr uint32_t WRITE_CELL_BALANCE_PERIOD_US = 100000UL; // 100 000 us = 10 Hz
     constexpr uint32_t WRITE_CELL_BALANCE_PRIORITY = 6;
-    constexpr uint32_t ALL_DATA_ETHERNET_PERIOD_US = 100000UL; // 100 000 us = 10 Hz
+    constexpr uint32_t ALL_DATA_ETHERNET_PERIOD_US = 50000UL; // 50 000 us = 20 Hz
     constexpr uint32_t ALL_DATA_ETHERNET_PRIORITY = 5;
     constexpr uint32_t CORE_DATA_ETHERNET_PERIOD_US = 10000UL; // 10 000 us = 100 Hz
     constexpr uint32_t CORE_DATA_ETHERNET_PRIORITY = 4;

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -30,7 +30,7 @@ const uint16_t under_voltage_threshold = 1874;  // 3.0V  // Minimum voltage valu
 const uint16_t over_voltage_threshold = 2625;   // 4.2V  // Maximum voltage value following datasheet formula: Comparison Voltage = VOV • 16 • 100μV
 const uint16_t gpio_enable = 0x1F;
 const uint16_t CRC15_POLY = 0x4599;             // Used for calculating the PEC table for LTC6811
-const float cv_adc_conversion_time_us = 8.0f;
-const float gpio_adc_conversion_time_us = 3.1f;
+const float cv_adc_conversion_time_us = 1.2f;
+const float gpio_adc_conversion_time_us = 1.2f;
 
 #endif

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -30,7 +30,7 @@ const uint16_t under_voltage_threshold = 1874;  // 3.0V  // Minimum voltage valu
 const uint16_t over_voltage_threshold = 2625;   // 4.2V  // Maximum voltage value following datasheet formula: Comparison Voltage = VOV • 16 • 100μV
 const uint16_t gpio_enable = 0x1F;
 const uint16_t CRC15_POLY = 0x4599;             // Used for calculating the PEC table for LTC6811
-const float cv_adc_conversion_time_us = 1.2f;
-const float gpio_adc_conversion_time_us = 1.2f;
+const float cv_adc_conversion_time_ms = 1.2f;
+const float gpio_adc_conversion_time_ms = 1.2f;
 
 #endif

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -30,7 +30,7 @@ const uint16_t under_voltage_threshold = 1874;  // 3.0V  // Minimum voltage valu
 const uint16_t over_voltage_threshold = 2625;   // 4.2V  // Maximum voltage value following datasheet formula: Comparison Voltage = VOV • 16 • 100μV
 const uint16_t gpio_enable = 0x1F;
 const uint16_t CRC15_POLY = 0x4599;             // Used for calculating the PEC table for LTC6811
-const float cv_adc_conversion_time_us = 13.0f;
+const float cv_adc_conversion_time_us = 8.0f;
 const float gpio_adc_conversion_time_us = 3.1f;
 
 #endif

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -30,6 +30,8 @@ const uint16_t under_voltage_threshold = 1874;  // 3.0V  // Minimum voltage valu
 const uint16_t over_voltage_threshold = 2625;   // 4.2V  // Maximum voltage value following datasheet formula: Comparison Voltage = VOV • 16 • 100μV
 const uint16_t gpio_enable = 0x1F;
 const uint16_t CRC15_POLY = 0x4599;             // Used for calculating the PEC table for LTC6811
+
+// unused because ht_sched task period accounts for adc conversion times
 const float cv_adc_conversion_time_ms = 1.2f;
 const float gpio_adc_conversion_time_ms = 1.2f;
 

--- a/lib/interfaces/include/BMSDriverGroup.h
+++ b/lib/interfaces/include/BMSDriverGroup.h
@@ -197,6 +197,8 @@ private:
      */
     void _start_wakeup_protocol();
 
+    void _start_wakeup_protocol(size_t cs);
+
     BMSDriverData _read_data_through_broadcast();
 
     BMSDriverData _read_data_through_address();

--- a/lib/interfaces/include/BMSDriverGroup.tpp
+++ b/lib/interfaces/include/BMSDriverGroup.tpp
@@ -96,20 +96,20 @@ template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
 typename BMSDriverGroup<num_chips, num_chip_selects, chip_type>::BMSDriverData
 BMSDriverGroup<num_chips, num_chip_selects, chip_type>::read_data()
 {
-    // _start_wakeup_protocol();             // wakes all of the ICs on the chip select line
-    _start_cell_voltage_ADC_conversion(); // Gets the ICs ready to be read, must delay afterwards by ? us
-
-    // _start_wakeup_protocol();
-    _start_GPIO_ADC_conversion();
-
+    BMSDriverData rtn;
     if constexpr (chip_type == LTC6811_Type_e::LTC6811_1)
     {
-        return _read_data_through_broadcast();
+        rtn = _read_data_through_broadcast();
     }
     else
     {
-        return _read_data_through_address();
+        rtn = _read_data_through_address();
     }
+
+    _start_cell_voltage_ADC_conversion(); // Gets the ICs ready to be read, must delay afterwards by ? us
+    _start_GPIO_ADC_conversion();
+
+    return rtn;
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
@@ -525,7 +525,7 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_ADC_conversi
 
     // Needs to be sent on each chip select line
     for (size_t cs = 0; cs < num_chip_selects; cs++) {
-        _start_wakeup_protocol(_chip_select[cs]);
+        _start_wakeup_protocol(cs);
         ltc_spi_interface::adc_conversion_command(_chip_select[cs], cmd_and_pec, (num_chips / num_chip_selects));
     }
 }

--- a/lib/interfaces/include/BMSDriverGroup.tpp
+++ b/lib/interfaces/include/BMSDriverGroup.tpp
@@ -181,15 +181,6 @@ BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_read_data_through_broad
             end = start + 10;
             std::copy(start, end, gpio_1_to_5_for_one_chip.begin());
             _bms_data = _load_auxillaries(_bms_data, max_min_reference, gpio_1_to_5_for_one_chip, chip_index, gpio_count);
-
-            // Serial.print("CHIP # "); Serial.print(chip_index); Serial.println(" : "); 
-            // for (auto voltage : _bms_data.voltages_by_chip[chip_index])
-            // {
-            //     if (voltage) {
-            //         Serial.print(*(voltage), 4); Serial.print(" ");
-            //     }
-            // }
-            // Serial.println();
         }
         
     }
@@ -490,7 +481,7 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_cell_voltage
         _start_ADC_conversion_through_address(cmd);
     }
 
-    delay(cv_adc_conversion_time_us); // us
+    delay(cv_adc_conversion_time_us); // ms
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
@@ -510,7 +501,7 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_GPIO_ADC_con
         _start_ADC_conversion_through_address(cmd);
     }
 
-    delay(gpio_adc_conversion_time_us); // us
+    delay(gpio_adc_conversion_time_us); // ms
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
@@ -620,12 +611,7 @@ std::array<uint8_t, 24 * (num_chips / num_chip_selects)> BMSDriverGroup<num_chip
         bms_data.valid_read_packets[chip + chip_iterator].valid_read_cells_7_to_9 = _check_if_valid_packet(cv_7_to_9, param_iterator);
         bms_data.valid_read_packets[chip + chip_iterator].valid_read_cells_10_to_12 = _check_if_valid_packet(cv_10_to_12, param_iterator);
     }
-
-    // for (int i = 0; i < 24 * num_chips_on_chip_select; i++) {
-    //     Serial.print(combined_cv_1_to_12[i]); Serial.print(" ");
-    // }
-    // Serial.println();
-
+    
     return combined_cv_1_to_12;
 }
 

--- a/lib/interfaces/include/BMSDriverGroup.tpp
+++ b/lib/interfaces/include/BMSDriverGroup.tpp
@@ -164,7 +164,6 @@ BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_read_data_through_broad
             _bms_data.valid_read_packets[chip_index].all_invalid_reads = _check_if_all_invalid(chip_index);
             if (_check_if_all_invalid(chip_index))
             {
-                Serial.print("we have invalid data at chip index "); Serial.println(chip_index);
                 continue;
             }
 
@@ -267,7 +266,6 @@ BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_load_cell_voltages(BMSD
     {
         if (_check_specific_packet_group_is_invalid(cell_Index, invalid_A, invalid_B, invalid_C, invalid_D)) {
             battery_cell_count++;
-            Serial.print("checked specific packet is invalid at "); Serial.println(battery_cell_count);
             continue;
         }
 
@@ -481,7 +479,7 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_cell_voltage
         _start_ADC_conversion_through_address(cmd);
     }
 
-    delay(cv_adc_conversion_time_us); // ms
+    // delay(cv_adc_conversion_time_us); // ms
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
@@ -501,7 +499,7 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_GPIO_ADC_con
         _start_ADC_conversion_through_address(cmd);
     }
 
-    delay(gpio_adc_conversion_time_us); // ms
+    // delay(gpio_adc_conversion_time_us); // ms
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>

--- a/lib/interfaces/include/BMSDriverGroup.tpp
+++ b/lib/interfaces/include/BMSDriverGroup.tpp
@@ -96,20 +96,20 @@ template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
 typename BMSDriverGroup<num_chips, num_chip_selects, chip_type>::BMSDriverData
 BMSDriverGroup<num_chips, num_chip_selects, chip_type>::read_data()
 {
-    BMSDriverData rtn;
+    BMSDriverData bms_data;
     if constexpr (chip_type == LTC6811_Type_e::LTC6811_1)
     {
-        rtn = _read_data_through_broadcast();
+        bms_data = _read_data_through_broadcast();
     }
     else
     {
-        rtn = _read_data_through_address();
+        bms_data = _read_data_through_address();
     }
 
     _start_cell_voltage_ADC_conversion(); // Gets the ICs ready to be read, must delay afterwards by ? us
     _start_GPIO_ADC_conversion();
 
-    return rtn;
+    return bms_data;
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
@@ -478,8 +478,6 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_cell_voltage
     {
         _start_ADC_conversion_through_address(cmd);
     }
-
-    // delay(cv_adc_conversion_time_us); // ms
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
@@ -498,8 +496,6 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_GPIO_ADC_con
     {
         _start_ADC_conversion_through_address(cmd);
     }
-
-    // delay(gpio_adc_conversion_time_us); // ms
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>

--- a/lib/interfaces/include/BMSDriverGroup.tpp
+++ b/lib/interfaces/include/BMSDriverGroup.tpp
@@ -33,18 +33,7 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_wakeup_proto
 {
     for (size_t cs = 0; cs < num_chip_selects; cs++)
     {
-        if constexpr (chip_type == LTC6811_Type_e::LTC6811_1)
-        {
-            ltc_spi_interface::_write_and_delay_low(_chip_select[cs], 400);
-            SPI.transfer16(0);
-            ltc_spi_interface::_write_and_delay_high(_chip_select[cs], 400);
-        }
-        else
-        {
-            ltc_spi_interface::_write_and_delay_low(_chip_select[cs], 400);
-            SPI.transfer(0);
-            ltc_spi_interface::_write_and_delay_high(_chip_select[cs], 400); // t_wake is 400 microseconds; wait that long to ensure device has turned on.
-        }
+        _start_wakeup_protocol(cs);
     }
 }
 

--- a/lib/interfaces/include/BMSDriverGroup.tpp
+++ b/lib/interfaces/include/BMSDriverGroup.tpp
@@ -49,6 +49,23 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_wakeup_proto
 }
 
 template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
+void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_wakeup_protocol(size_t cs)
+{
+    if constexpr (chip_type == LTC6811_Type_e::LTC6811_1)
+    {
+        ltc_spi_interface::_write_and_delay_low(_chip_select[cs], 400);
+        SPI.transfer16(0);
+        ltc_spi_interface::_write_and_delay_high(_chip_select[cs], 400);
+    }
+    else
+    {
+        ltc_spi_interface::_write_and_delay_low(_chip_select[cs], 400);
+        SPI.transfer(0);
+        ltc_spi_interface::_write_and_delay_high(_chip_select[cs], 400); // t_wake is 400 microseconds; wait that long to ensure device has turned on.
+    }
+}
+
+template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
 constexpr std::array<uint16_t, 256> BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_initialize_Pec_Table()
 {
     std::array<uint16_t, 256> temp{};
@@ -79,10 +96,10 @@ template <size_t num_chips, size_t num_chip_selects, LTC6811_Type_e chip_type>
 typename BMSDriverGroup<num_chips, num_chip_selects, chip_type>::BMSDriverData
 BMSDriverGroup<num_chips, num_chip_selects, chip_type>::read_data()
 {
-    _start_wakeup_protocol();             // wakes all of the ICs on the chip select line
+    // _start_wakeup_protocol();             // wakes all of the ICs on the chip select line
     _start_cell_voltage_ADC_conversion(); // Gets the ICs ready to be read, must delay afterwards by ? us
 
-    _start_wakeup_protocol();
+    // _start_wakeup_protocol();
     _start_GPIO_ADC_conversion();
 
     if constexpr (chip_type == LTC6811_Type_e::LTC6811_1)
@@ -110,25 +127,25 @@ BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_read_data_through_broad
         write_configuration(_config.dcto_read, _cell_discharge_en);
 
         // Get buffers for each group we care about, all at once for ONE chip select line
-        _start_wakeup_protocol();
+        _start_wakeup_protocol(cs);
         auto cmd_pec = _generate_CMD_PEC(CMD_CODES_e::READ_CELL_VOLTAGE_GROUP_A, -1); // The address should never be used here
         auto data_in_cell_voltages_1_to_3 = ltc_spi_interface::read_registers_command<data_size>(_chip_select[cs], cmd_pec);
-        _start_wakeup_protocol();
+        _start_wakeup_protocol(cs);
         cmd_pec = _generate_CMD_PEC(CMD_CODES_e::READ_CELL_VOLTAGE_GROUP_B, -1);
         auto data_in_cell_voltages_4_to_6 = ltc_spi_interface::read_registers_command<data_size>(_chip_select[cs], cmd_pec);
-        _start_wakeup_protocol();
+        _start_wakeup_protocol(cs);
         cmd_pec = _generate_CMD_PEC(CMD_CODES_e::READ_CELL_VOLTAGE_GROUP_C, -1);
         auto data_in_cell_voltages_7_to_9 = ltc_spi_interface::read_registers_command<data_size>(_chip_select[cs], cmd_pec);
-        _start_wakeup_protocol();
+        _start_wakeup_protocol(cs);
         cmd_pec = _generate_CMD_PEC(CMD_CODES_e::READ_CELL_VOLTAGE_GROUP_D, -1);
         auto data_in_cell_voltages_10_to_12 = ltc_spi_interface::read_registers_command<data_size>(_chip_select[cs], cmd_pec);
-        _start_wakeup_protocol();
+        _start_wakeup_protocol(cs);
         cmd_pec = _generate_CMD_PEC(CMD_CODES_e::READ_GPIO_VOLTAGE_GROUP_A, -1);
         auto data_in_auxillaries_1_to_3 = ltc_spi_interface::read_registers_command<data_size>(_chip_select[cs], cmd_pec);
-        _start_wakeup_protocol();
+        _start_wakeup_protocol(cs);
         cmd_pec = _generate_CMD_PEC(CMD_CODES_e::READ_GPIO_VOLTAGE_GROUP_B, -1);
         auto data_in_auxillaries_4_to_6 = ltc_spi_interface::read_registers_command<data_size>(_chip_select[cs], cmd_pec);
-
+        
         // store the data for all chips on a chip select into one array, no PEC included
         std::array<uint8_t, 24 * (num_chips / num_chip_selects)> data_in_cell_voltages_1_to_12 = _package_cell_voltages(_bms_data, cs, data_in_cell_voltages_1_to_3,
                                                                                                                         data_in_cell_voltages_4_to_6,
@@ -147,25 +164,36 @@ BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_read_data_through_broad
             _bms_data.valid_read_packets[chip_index].all_invalid_reads = _check_if_all_invalid(chip_index);
             if (_check_if_all_invalid(chip_index))
             {
+                Serial.print("we have invalid data at chip index "); Serial.println(chip_index);
                 continue;
             }
 
             // load cell voltages function
             std::array<uint8_t, 24> cv_1_to_12_for_one_chip;
-            auto start = data_in_cell_voltages_1_to_12.begin() + (chip_index * 24);
+            auto start = data_in_cell_voltages_1_to_12.begin() + (chip * 24);
             auto end = start + 24;
             std::copy(start, end, cv_1_to_12_for_one_chip.begin());
             _bms_data = _load_cell_voltages(_bms_data, max_min_reference, cv_1_to_12_for_one_chip, chip_index, battery_cell_count);
 
             // load humidity / temperatures function
             std::array<uint8_t, 10> gpio_1_to_5_for_one_chip;
-            start = data_in_temps_1_to_5.begin() + (chip_index * 10);
+            start = data_in_temps_1_to_5.begin() + (chip * 10);
             end = start + 10;
             std::copy(start, end, gpio_1_to_5_for_one_chip.begin());
             _bms_data = _load_auxillaries(_bms_data, max_min_reference, gpio_1_to_5_for_one_chip, chip_index, gpio_count);
-        }
-    }
 
+            // Serial.print("CHIP # "); Serial.print(chip_index); Serial.println(" : "); 
+            // for (auto voltage : _bms_data.voltages_by_chip[chip_index])
+            // {
+            //     if (voltage) {
+            //         Serial.print(*(voltage), 4); Serial.print(" ");
+            //     }
+            // }
+            // Serial.println();
+        }
+        
+    }
+    
     _bms_data.min_cell_voltage = max_min_reference.min_cell_voltage;
     _bms_data.max_cell_voltage = max_min_reference.max_cell_voltage;
     _bms_data.total_voltage = _sum_cell_voltages();
@@ -244,11 +272,11 @@ BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_load_cell_voltages(BMSD
     bool invalid_B = !packet_data.valid_read_cells_4_to_6;
     bool invalid_C = !packet_data.valid_read_cells_7_to_9;
     bool invalid_D = !packet_data.valid_read_cells_10_to_12;
-
     for (int cell_Index = 0; cell_Index < cell_count; cell_Index++)
     {
         if (_check_specific_packet_group_is_invalid(cell_Index, invalid_A, invalid_B, invalid_C, invalid_D)) {
             battery_cell_count++;
+            Serial.print("checked specific packet is invalid at "); Serial.println(battery_cell_count);
             continue;
         }
 
@@ -266,7 +294,6 @@ BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_load_cell_voltages(BMSD
         battery_cell_count++;
     }
     std::copy(chip_voltages_in.data(), chip_voltages_in.data() + cell_count, bms_data.voltages_by_chip[chip_index].data());
-
     return bms_data;
 }
 
@@ -497,8 +524,8 @@ void BMSDriverGroup<num_chips, num_chip_selects, chip_type>::_start_ADC_conversi
     std::copy(pec.begin(), pec.end(), cmd_and_pec.begin() + 2);       // Copy next two bytes (pec)
 
     // Needs to be sent on each chip select line
-    for (size_t cs = 0; cs < num_chip_selects; cs++)
-    {
+    for (size_t cs = 0; cs < num_chip_selects; cs++) {
+        _start_wakeup_protocol(_chip_select[cs]);
         ltc_spi_interface::adc_conversion_command(_chip_select[cs], cmd_and_pec, (num_chips / num_chip_selects));
     }
 }
@@ -593,6 +620,12 @@ std::array<uint8_t, 24 * (num_chips / num_chip_selects)> BMSDriverGroup<num_chip
         bms_data.valid_read_packets[chip + chip_iterator].valid_read_cells_7_to_9 = _check_if_valid_packet(cv_7_to_9, param_iterator);
         bms_data.valid_read_packets[chip + chip_iterator].valid_read_cells_10_to_12 = _check_if_valid_packet(cv_10_to_12, param_iterator);
     }
+
+    // for (int i = 0; i < 24 * num_chips_on_chip_select; i++) {
+    //     Serial.print(combined_cv_1_to_12[i]); Serial.print(" ");
+    // }
+    // Serial.println();
+
     return combined_cv_1_to_12;
 }
 

--- a/lib/interfaces/include/LTCSPIInterface.tpp
+++ b/lib/interfaces/include/LTCSPIInterface.tpp
@@ -69,10 +69,6 @@ void ltc_spi_interface::adc_conversion_command(int cs, std::array<uint8_t, 4> cm
     for (size_t i = 0; i < num_stacked_devices; i++) {
         SPI.transfer(0);
     }
-    elapsedMillis timer = 0;
-    while (timer < 15) {
-        SPI.transfer(0);
-    }
     _write_and_delay_high(cs, 5);
     // End Messager
     SPI.endTransaction();

--- a/lib/interfaces/include/LTCSPIInterface.tpp
+++ b/lib/interfaces/include/LTCSPIInterface.tpp
@@ -53,7 +53,7 @@ std::array<uint8_t, buffer_size> ltc_spi_interface::read_registers_command(int c
     // Prompts SPI enable
     _write_and_delay_low(cs, 5);
     _transfer_SPI_data<4>(cmd_and_pec);
- 
+
     read_in = _receive_SPI_data<buffer_size>();
     
     _write_and_delay_high(cs, 5); 

--- a/lib/interfaces/include/WatchdogInterface.h
+++ b/lib/interfaces/include/WatchdogInterface.h
@@ -95,6 +95,7 @@ private:
     const float _pack_and_ts_out_conv_factor = 0.00482F;
     const float _bspd_current_conv_factor = 0.5118F;
     const float _glv_conv_factor = 0.1036F;
+    const float _shutdown_voltage_digital_threshold = 12.0F;
 
 public: 
     /**

--- a/lib/interfaces/include/WatchdogInterface.h
+++ b/lib/interfaces/include/WatchdogInterface.h
@@ -40,7 +40,7 @@ public:
         pin pack_out_filtered_pin = pin_default_params::PACK_OUT_FILTERED_PIN,
         pin bspd_current_pin = pin_default_params::BSPD_CURRENT_PIN,
         pin scaled_24V_pin = pin_default_params::SCALED_24V_PIN,
-        const uint32_t kick_interval_ms = 10UL) : 
+        const uint32_t kick_interval_ms = 9UL) : 
                         _teensy_wd_kick_pin(wd_kick_pin),
                         _teensy_ok_pin(teensy_ok_pin),
                         _teensy_n_latch_en_pin(n_latch_pin),

--- a/lib/interfaces/include/WatchdogInterface.h
+++ b/lib/interfaces/include/WatchdogInterface.h
@@ -15,6 +15,7 @@ namespace pin_default_params
     constexpr const pin TS_OUT_FILTERED_PIN = 17;
     constexpr const pin PACK_OUT_FILTERED_PIN = 18;
     constexpr const pin IMD_OK_PIN = 25;
+    constexpr const pin PRECHARGE_PIN = 26;
     constexpr const pin BSPD_CURRENT_PIN = 27;
     constexpr const pin SHDN_OUT_PIN = 38;
     constexpr const pin SCALED_24V_PIN = 39;
@@ -35,6 +36,7 @@ public:
         pin wd_kick_pin = pin_default_params::WD_KICK_PIN, 
         pin n_latch_pin = pin_default_params::N_LATCH_EN_PIN,
         pin imd_ok_pin = pin_default_params::IMD_OK_PIN, 
+        pin precharge_pin = pin_default_params::PRECHARGE_PIN,
         pin shdn_out_pin = pin_default_params::SHDN_OUT_PIN,
         pin ts_out_filtered_pin = pin_default_params::TS_OUT_FILTERED_PIN,
         pin pack_out_filtered_pin = pin_default_params::PACK_OUT_FILTERED_PIN,
@@ -45,6 +47,7 @@ public:
                         _teensy_ok_pin(teensy_ok_pin),
                         _teensy_n_latch_en_pin(n_latch_pin),
                         _teensy_imd_ok_pin(imd_ok_pin),
+                        _teensy_precharge_pin(precharge_pin),
                         _teensy_shdn_out_pin(shdn_out_pin),
                         _teensy_ts_out_filtered_pin(ts_out_filtered_pin),
                         _teensy_pack_out_filtered_pin(pack_out_filtered_pin),
@@ -67,6 +70,7 @@ private:
     const pin _teensy_ok_pin;   // > Needs to stay HIGH while wd_kick_pin flips to keep BMS_OK high
     const pin _teensy_n_latch_en_pin; // > Input to Safety Light, true when teensy is not in FAULT state
     const pin _teensy_imd_ok_pin; // < READ from IMD hardware, go to FAULT state if HIGH
+    const pin _teensy_precharge_pin; // READ from PRECHARGE
     const pin _teensy_shdn_out_pin; // < READ from SHDN hardware, can leave FAULT state if goes to HIGH to signify car startup
     const pin _teensy_ts_out_filtered_pin;
     const pin _teensy_pack_out_filtered_pin;
@@ -84,6 +88,8 @@ private:
     const uint32_t _imd_startup_time = 2000;
     const float _bit_resolution = 4095.0F;
     const float _teensy41_max_input_voltage = 3.3F;
+    const float _shutdown_conv_factor = 0.1155F; // voltage divider -> 4.7k / (4.7k + 36k)
+    const float _precharge_conv_factor = 0.6623F; // voltage divider -> 10k / (5.1k + 10k)
     const float _teensy41_min_digital_read_voltage_thresh = 0.2F;
     const float _teensy41_max_digital_read_voltage_thresh = 3.0F;
     const float _pack_and_ts_out_conv_factor = 0.00482F;
@@ -118,9 +124,16 @@ public:
     bool read_imd_ok(uint32_t curr_millis);
 
     /**
-     * @return the state of SHDN_OUT, HIGH = CAR was STARTED UP
+     * @return the state of SHDN_OUT, HIGH = CAR was LATCHED
     */
     bool read_shdn_out();
+    volt read_shdn_voltage();
+
+    /**
+     * @return the state of PRECHARGE -- HIGH indicates precharge relay is closed
+     */
+    bool read_precharge_out();
+    volt read_precharge_voltage();
 
     /**
      * @return voltage values of filtered TS OUT and PACK OUT

--- a/lib/interfaces/src/ACUEthernetInterface.cpp
+++ b/lib/interfaces/src/ACUEthernetInterface.cpp
@@ -37,10 +37,11 @@ hytech_msgs_ACUCoreData ACUEthernetInterface::make_acu_core_data_msg(const ACUCo
     out.avg_cell_voltage = shared_state.avg_cell_voltage;
     out.max_cell_temp = shared_state.max_cell_temp;
 
-    out.measured_glv = shared_state.measured_glv;
+    out.max_measured_glv = shared_state.max_measured_glv;
     out.max_board_temp = shared_state.max_board_temp;
-    out.measured_pack_voltage = shared_state.measured_pack_out_voltage;
-    out.measured_tractive_system_voltage = shared_state.measured_ts_out_voltage;
+    out.max_measured_pack_voltage = shared_state.max_measured_pack_out_voltage;
+    out.max_measured_tractive_system_voltage = shared_state.max_measured_ts_out_voltage;
+    out.min_measured_shdn_out_voltage = shared_state.min_shdn_out_voltage;
 
     return out;
 }

--- a/lib/interfaces/src/ACUEthernetInterface.cpp
+++ b/lib/interfaces/src/ACUEthernetInterface.cpp
@@ -41,6 +41,9 @@ hytech_msgs_ACUCoreData ACUEthernetInterface::make_acu_core_data_msg(const ACUCo
     out.max_board_temp = shared_state.max_board_temp;
     out.max_measured_pack_voltage = shared_state.max_measured_pack_out_voltage;
     out.max_measured_tractive_system_voltage = shared_state.max_measured_ts_out_voltage;
+    out.min_measured_glv = shared_state.min_measured_glv;
+    out.min_measured_pack_voltage = shared_state.min_measured_pack_out_voltage;
+    out.min_measured_tractive_system_voltage = shared_state.min_measured_ts_out_voltage;
     out.min_measured_shdn_out_voltage = shared_state.min_shdn_out_voltage;
 
     return out;

--- a/lib/interfaces/src/CCUInterface.cpp
+++ b/lib/interfaces/src/CCUInterface.cpp
@@ -20,7 +20,7 @@ void CCUInterface::handle_enqueue_acu_status_CAN_message() {
     } else {
         msg.state = 1; // discharging
     }
-    // Serial.println("ACU STATUS CAN msg enqueued");
+
     CAN_util::enqueue_msg(&msg, &Pack_BMS_STATUS_hytech, ACUCANInterfaceImpl::ccu_can_tx_buffer);
 }  
 
@@ -40,7 +40,7 @@ void CCUInterface::handle_enqueue_acu_voltages_CAN_message() {
     detailed_msg.voltage_0_ro = HYTECH_voltage_0_ro_toS(_acu_all_data.cell_voltages[_curr_data.detailed_voltages_cell_id]); 
     detailed_msg.voltage_1_ro = HYTECH_voltage_1_ro_toS(_acu_all_data.cell_voltages[_curr_data.detailed_voltages_cell_id+1]); 
     detailed_msg.voltage_2_ro = HYTECH_voltage_2_ro_toS(_acu_all_data.cell_voltages[_curr_data.detailed_voltages_cell_id+2]); 
-    //Serial.printf("Chip %d Group %d\n", _curr_data.detailed_voltages_ic_id, _curr_data.detailed_voltages_group_id);
+
     if (_curr_data.detailed_voltages_ic_id % 2 == 0) {
         _curr_data.detailed_voltages_group_id = (_curr_data.detailed_voltages_group_id == 3) ? 0 : _curr_data.detailed_voltages_group_id+1;
     } else {
@@ -61,7 +61,7 @@ void CCUInterface::handle_enqueue_acu_temps_CAN_message() {
     detailed_msg.thermistor_id_0_ro = HYTECH_thermistor_id_0_ro_toS(_acu_all_data.cell_temps[_curr_data.detailed_temps_cell_id]); 
     detailed_msg.thermistor_id_1_ro = HYTECH_thermistor_id_1_ro_toS(_acu_all_data.cell_temps[_curr_data.detailed_temps_cell_id+1]); 
     detailed_msg.thermistor_id_2_ro = HYTECH_thermistor_id_2_ro_toS(_acu_all_data.cell_temps[_curr_data.detailed_temps_cell_id+2]); 
-    //Serial.printf("Chip %d Group %d\n", _curr_data.detailed_temps_ic_id, _curr_data.detailed_temps_group_id);
+    
     _curr_data.detailed_temps_group_id = (_curr_data.detailed_temps_group_id == 1) ? 0 : _curr_data.detailed_temps_group_id+1;
     if (_curr_data.detailed_temps_group_id == 0) {
         _curr_data.detailed_temps_ic_id = (_curr_data.detailed_temps_ic_id == (NUM_CHIPS - 1)) ? 0 : _curr_data.detailed_temps_ic_id+1;

--- a/lib/interfaces/src/WatchdogInterface.cpp
+++ b/lib/interfaces/src/WatchdogInterface.cpp
@@ -62,7 +62,7 @@ volt WatchdogInterface::read_shdn_voltage() {
 }
 
 bool WatchdogInterface::read_shdn_out() {
-    bool data = read_shdn_voltage() > 12.0F; // read shdn out goes high if shutdown voltage is > 12 volts
+    bool data = read_shdn_voltage() > _shutdown_voltage_digital_threshold; // read shdn out goes high if shutdown voltage is > 12 volts
     return data;
 }
 

--- a/lib/interfaces/src/WatchdogInterface.cpp
+++ b/lib/interfaces/src/WatchdogInterface.cpp
@@ -55,8 +55,25 @@ bool WatchdogInterface::read_imd_ok(uint32_t curr_millis) {
     return (static_cast<float>(analogRead(_teensy_imd_ok_pin)) * (_teensy41_max_input_voltage / _bit_resolution)) > _teensy41_min_digital_read_voltage_thresh; // idk if this would actually work, like if a LOW is a threshold or smth
 }
 
+volt WatchdogInterface::read_shdn_voltage() {
+    // 3.3 V for pin voltage cap. and 4095 for bit resolution
+    volt data = static_cast<float>(analogRead(_teensy_shdn_out_pin)) * (_teensy41_max_input_voltage / _bit_resolution) / (_shutdown_conv_factor); 
+    return data;
+}
+
 bool WatchdogInterface::read_shdn_out() {
-    bool data = digitalRead(_teensy_shdn_out_pin);
+    bool data = read_shdn_voltage() > 12.0F; // read shdn out goes high if shutdown voltage is > 12 volts
+    return data;
+}
+
+volt WatchdogInterface::read_precharge_voltage() {
+    // 3.3 V for pin voltage cap
+    volt data = static_cast<float>(analogRead(_teensy_precharge_pin)) * (_teensy41_max_input_voltage / _bit_resolution) / (_precharge_conv_factor);
+    return data;
+}
+
+bool WatchdogInterface::read_precharge_out() {
+    bool data = read_precharge_voltage() > _teensy41_min_digital_read_voltage_thresh;
     return data;
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,7 @@
 [common]
 lib_deps_shared = 
   https://github.com/hytech-racing/shared_firmware_systems.git
-  https://github.com/hytech-racing/shared_firmware_types.git#5281675b9d68adc1429e587669653ac2ddd25f57
+  https://github.com/hytech-racing/shared_firmware_types.git#83f274a7929178dcf24cb11c083bf840bac6a82b
   Embedded Template Library@^20.39.4
 
 ; Teensy41 Environment. This environment is the primary environment for uploading code to the car.
@@ -76,7 +76,7 @@ lib_deps=
     https://github.com/ssilverman/QNEthernet#v0.26.0
     https://github.com/hytech-racing/HT_CAN/releases/download/163/can_lib.tar.gz
     https://github.com/hytech-racing/HT_SCHED.git
-    https://github.com/hytech-racing/HT_proto/releases/download/2025-05-09T15_45_17/hytech_msgs_pb_lib.tar.gz
+    https://github.com/hytech-racing/HT_proto/releases/download/2025-08-27T15_34_50/hytech_msgs_pb_lib.tar.gz
     https://github.com/hytech-racing/shared_firmware_interfaces.git
     https://github.com/KSU-MS/pio-git-hash-gen#7998b5b3f8a2464209b0e73338717998bcf511ee
     Nanopb

--- a/src/ACU_InterfaceTasks.cpp
+++ b/src/ACU_InterfaceTasks.cpp
@@ -7,13 +7,13 @@ const size_t num_total_bms_packets = ACUConstants::NUM_CHIPS * sizeof(BMSFaultCo
 void initialize_all_interfaces()
 {
     SPI.begin();
-    SPI.setClockDivider(SPI_CLOCK_DIV2); // 16MHz (Arduino Clock Frequency) / 2 = 8MHz -> SPI Clock
+    SPI.setClockDivider(SPI_CLOCK_DIV8); // 16MHz (Arduino Clock Frequency) / 2 = 8MHz -> SPI Clock
     Serial.begin(ACUConstants::SERIAL_BAUDRATE);
     analogReadResolution(ACUConstants::ANALOG_READ_RESOLUTION);
 
     /* Watchdog Interface */
     WatchdogInstance::create();
-    WatchdogInstance::instance().init(sys_time::hal_millis()); 
+    WatchdogInstance::instance().init(sys_time::hal_millis());
 
     /* ACU Data Struct */
     ACUDataInstance::create();
@@ -200,6 +200,9 @@ HT_TASK::TaskResponse idle_sample_interfaces(const unsigned long& sysMicros, con
     if (WatchdogInstance::instance().read_pack_out_filtered() > ACUAllDataInstance::instance().core_data.max_measured_pack_out_voltage) { ACUAllDataInstance::instance().core_data.max_measured_pack_out_voltage = WatchdogInstance::instance().read_pack_out_filtered(); }
     if (WatchdogInstance::instance().read_ts_out_filtered() > ACUAllDataInstance::instance().core_data.max_measured_ts_out_voltage) { ACUAllDataInstance::instance().core_data.max_measured_ts_out_voltage = WatchdogInstance::instance().read_ts_out_filtered(); }
     
+    if (WatchdogInstance::instance().read_global_lv_value() < ACUAllDataInstance::instance().core_data.min_measured_glv) { ACUAllDataInstance::instance().core_data.min_measured_glv = WatchdogInstance::instance().read_global_lv_value(); }
+    if (WatchdogInstance::instance().read_pack_out_filtered() < ACUAllDataInstance::instance().core_data.min_measured_pack_out_voltage) { ACUAllDataInstance::instance().core_data.min_measured_pack_out_voltage = WatchdogInstance::instance().read_pack_out_filtered(); }
+    if (WatchdogInstance::instance().read_ts_out_filtered() < ACUAllDataInstance::instance().core_data.min_measured_ts_out_voltage) { ACUAllDataInstance::instance().core_data.min_measured_ts_out_voltage = WatchdogInstance::instance().read_ts_out_filtered(); }
     if (WatchdogInstance::instance().read_shdn_voltage() < ACUAllDataInstance::instance().core_data.min_shdn_out_voltage) { ACUAllDataInstance::instance().core_data.min_shdn_out_voltage = WatchdogInstance::instance().read_shdn_voltage(); }
     
     return HT_TASK::TaskResponse::YIELD;

--- a/src/ACU_InterfaceTasks.cpp
+++ b/src/ACU_InterfaceTasks.cpp
@@ -135,9 +135,10 @@ HT_TASK::TaskResponse handle_send_ACU_all_ethernet_data(const unsigned long &sys
     ACUAllDataInstance::instance().measured_bspd_current = WatchdogInstance::instance().read_bspd_current();
 
     ACUEthernetInterfaceInstance::instance().handle_send_ethernet_acu_all_data(ACUEthernetInterfaceInstance::instance().make_acu_all_data_msg(ACUAllDataInstance::instance()));
-    ACUAllDataInstance::instance().core_data.measured_glv = 0;
-    ACUAllDataInstance::instance().core_data.measured_pack_out_voltage = 0;
-    ACUAllDataInstance::instance().core_data.measured_ts_out_voltage = 0;
+    ACUAllDataInstance::instance().core_data.max_measured_glv = 0;
+    ACUAllDataInstance::instance().core_data.max_measured_pack_out_voltage = 0;
+    ACUAllDataInstance::instance().core_data.max_measured_ts_out_voltage = 0;
+    ACUAllDataInstance::instance().core_data.min_shdn_out_voltage = 65535;
 
     return HT_TASK::TaskResponse::YIELD;
 }
@@ -195,9 +196,12 @@ HT_TASK::TaskResponse sample_CAN_data(const unsigned long& sysMicros, const HT_T
 
 HT_TASK::TaskResponse idle_sample_interfaces(const unsigned long& sysMicros, const HT_TASK::TaskInfo& taskInfo) {
     /* Find the maximums of GLV, Pack out, and TS Out within every ethernet send period */
-    if (WatchdogInstance::instance().read_global_lv_value() > ACUAllDataInstance::instance().core_data.measured_glv) { ACUAllDataInstance::instance().core_data.measured_glv = WatchdogInstance::instance().read_global_lv_value(); }
-    if (WatchdogInstance::instance().read_pack_out_filtered() > ACUAllDataInstance::instance().core_data.measured_pack_out_voltage) { ACUAllDataInstance::instance().core_data.measured_pack_out_voltage = WatchdogInstance::instance().read_pack_out_filtered(); }
-    if (WatchdogInstance::instance().read_ts_out_filtered() > ACUAllDataInstance::instance().core_data.measured_ts_out_voltage) { ACUAllDataInstance::instance().core_data.measured_ts_out_voltage = WatchdogInstance::instance().read_ts_out_filtered(); }
+    if (WatchdogInstance::instance().read_global_lv_value() > ACUAllDataInstance::instance().core_data.max_measured_glv) { ACUAllDataInstance::instance().core_data.max_measured_glv = WatchdogInstance::instance().read_global_lv_value(); }
+    if (WatchdogInstance::instance().read_pack_out_filtered() > ACUAllDataInstance::instance().core_data.max_measured_pack_out_voltage) { ACUAllDataInstance::instance().core_data.max_measured_pack_out_voltage = WatchdogInstance::instance().read_pack_out_filtered(); }
+    if (WatchdogInstance::instance().read_ts_out_filtered() > ACUAllDataInstance::instance().core_data.max_measured_ts_out_voltage) { ACUAllDataInstance::instance().core_data.max_measured_ts_out_voltage = WatchdogInstance::instance().read_ts_out_filtered(); }
+    
+    if (WatchdogInstance::instance().read_shdn_voltage() < ACUAllDataInstance::instance().core_data.min_shdn_out_voltage) { ACUAllDataInstance::instance().core_data.min_shdn_out_voltage = WatchdogInstance::instance().read_shdn_voltage(); }
+    
     return HT_TASK::TaskResponse::YIELD;
 }
 
@@ -346,7 +350,7 @@ HT_TASK::TaskResponse debug_print(const unsigned long &sysMicros, const HT_TASK:
     Serial.print(ACUDataInstance::instance().SoC * 100, 3);
     Serial.println("%");
     Serial.print("Measured GLV: ");
-    Serial.print(ACUAllDataInstance::instance().core_data.measured_glv, 3);
+    Serial.print(ACUAllDataInstance::instance().core_data.max_measured_glv, 3);
     Serial.println("V");
     Serial.println();
 

--- a/src/ACU_InterfaceTasks.cpp
+++ b/src/ACU_InterfaceTasks.cpp
@@ -306,7 +306,12 @@ HT_TASK::TaskResponse debug_print(const unsigned long &sysMicros, const HT_TASK:
     }
 
     Serial.printf("IMD OK: %d\n", WatchdogInstance::instance().read_imd_ok(sys_time::hal_millis()));
+
+    Serial.printf("SHDN VOLTAGE: %d\t", WatchdogInstance::instance().read_shdn_voltage());
     Serial.printf("SHDN OUT: %d\n", WatchdogInstance::instance().read_shdn_out());
+
+    Serial.printf("PRECHARGE VOLTAGE: %d\t", WatchdogInstance::instance().read_precharge_voltage());
+    Serial.printf("PRECHARGE OUT: %d\n", WatchdogInstance::instance().read_precharge_out());
 
     Serial.print("TS OUT Filtered: ");
     Serial.println(WatchdogInstance::instance().read_ts_out_filtered(), 4);
@@ -347,27 +352,27 @@ HT_TASK::TaskResponse debug_print(const unsigned long &sysMicros, const HT_TASK:
 
     Serial.print("Number of Global Faults: ");
     Serial.println(ACUDataInstance::instance().max_consecutive_invalid_packet_count);
-    Serial.println("Number of Consecutive Faults Per Chip: ");
-    for (size_t c = 0; c < ACUConstants::NUM_CHIPS; c++) {
-        Serial.print("CHIP ");
-        Serial.print(c);
-        Serial.print(": ");
-        Serial.print(ACUFaultDataInstance::instance().consecutive_invalid_packet_counts[c]);
-        Serial.print("\t");
-        Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_cell_1_to_3_count);
-        Serial.print(" ");
-        Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_cell_4_to_6_count);
-        Serial.print(" ");
-        Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_cell_7_to_9_count);
-        Serial.print(" ");
-        Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_cell_10_to_12_count);
-        Serial.print(" ");
-        Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_gpio_1_to_3_count);
-        Serial.print(" ");
-        Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_gpio_4_to_6_count);
-        Serial.print(" ");
-    }
-    Serial.println();
+    // Serial.println("Number of Consecutive Faults Per Chip: ");
+    // for (size_t c = 0; c < ACUConstants::NUM_CHIPS; c++) {
+    //     Serial.print("CHIP ");
+    //     Serial.print(c);
+    //     Serial.print(": ");
+    //     Serial.print(ACUFaultDataInstance::instance().consecutive_invalid_packet_counts[c]);
+    //     Serial.print("\t");
+    //     Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_cell_1_to_3_count);
+    //     Serial.print(" ");
+    //     Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_cell_4_to_6_count);
+    //     Serial.print(" ");
+    //     Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_cell_7_to_9_count);
+    //     Serial.print(" ");
+    //     Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_cell_10_to_12_count);
+    //     Serial.print(" ");
+    //     Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_gpio_1_to_3_count);
+    //     Serial.print(" ");
+    //     Serial.print(ACUFaultDataInstance::instance().chip_invalid_cmd_counts[c].invalid_gpio_4_to_6_count);
+    //     Serial.print(" ");
+    // }
+    // Serial.println();
 
     return HT_TASK::TaskResponse::YIELD;
 }

--- a/src/ACU_InterfaceTasks.cpp
+++ b/src/ACU_InterfaceTasks.cpp
@@ -113,7 +113,7 @@ HT_TASK::TaskResponse sample_bms_data(const unsigned long &sysMicros, const HT_T
     ACUDataInstance::instance().max_consecutive_invalid_packet_count = *etl::max_element(chip_max_invalid_cmd_counts.begin(), chip_max_invalid_cmd_counts.end());
     ACUAllDataInstance::instance().max_consecutive_invalid_packet_count = ACUDataInstance::instance().max_consecutive_invalid_packet_count;
     ACUAllDataInstance::instance().consecutive_invalid_packet_counts = ACUFaultDataInstance::instance().consecutive_invalid_packet_counts;
-    //print_bms_data(data);
+    print_bms_data(data);
     return HT_TASK::TaskResponse::YIELD;
 }
 

--- a/src/ACU_InterfaceTasks.cpp
+++ b/src/ACU_InterfaceTasks.cpp
@@ -7,7 +7,7 @@ const size_t num_total_bms_packets = ACUConstants::NUM_CHIPS * sizeof(BMSFaultCo
 void initialize_all_interfaces()
 {
     SPI.begin();
-    SPI.setClockDivider(SPI_CLOCK_DIV8); // 16MHz (Arduino Clock Frequency) / 2 = 8MHz -> SPI Clock
+    SPI.setClockDivider(SPI_CLOCK_DIV8); // 16MHz (Arduino Clock Frequency) / 8 = 2MHz -> SPI Clock
     Serial.begin(ACUConstants::SERIAL_BAUDRATE);
     analogReadResolution(ACUConstants::ANALOG_READ_RESOLUTION);
 
@@ -113,7 +113,7 @@ HT_TASK::TaskResponse sample_bms_data(const unsigned long &sysMicros, const HT_T
     ACUDataInstance::instance().max_consecutive_invalid_packet_count = *etl::max_element(chip_max_invalid_cmd_counts.begin(), chip_max_invalid_cmd_counts.end());
     ACUAllDataInstance::instance().max_consecutive_invalid_packet_count = ACUDataInstance::instance().max_consecutive_invalid_packet_count;
     ACUAllDataInstance::instance().consecutive_invalid_packet_counts = ACUFaultDataInstance::instance().consecutive_invalid_packet_counts;
-    print_bms_data(data);
+    // print_bms_data(data);
     return HT_TASK::TaskResponse::YIELD;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,7 @@ void setup()
     scheduler.schedule(write_cell_balancing_config_task);
 
     scheduler.schedule(send_all_data_ethernet_task);
-    scheduler.schedule(send_core_data_ethernet_task);
+    scheduler.schedule(send_core_data_ethernet_task); // waiting on update on drivebrain
 
     scheduler.schedule(send_CAN_task);
     scheduler.schedule(enqueue_CCU_core_CAN_task);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,7 +67,7 @@ void setup()
     scheduler.schedule(sample_CAN_task);
     scheduler.schedule(idle_sample_task);
 
-    scheduler.schedule(debug_prints_task);
+    // scheduler.schedule(debug_prints_task);
 
     handle_CAN_setup(ACUCANInterfaceImpl::CCU_CAN, ACUConstants::Veh_CAN_baudrate, &ACUCANInterfaceImpl::on_ccu_can_receive);
     handle_CAN_setup(ACUCANInterfaceImpl::EM_CAN, ACUConstants::EM_CAN_baudrate, &ACUCANInterfaceImpl::on_em_can_receive);


### PR DESCRIPTION
bms driver had some fatal indexing problems that surfaced when trying to use 2 chip selects on ltc6811-1. This is not the same for ltc6811-2. 

The startup wakeup protocol that's used to wakeup the chip was also written lazily. It only woke up the chip select lines together. before going to the adc polling commands. Thus, the adc polling command for the SECOND chip select line was delayed. Essentially:

Do wakeup on CS 9, adc poll on CS 9, then wakeup on CS 10, adc poll on CS 10. 
INSTEAD OF wakeup on CS 9, wakeup on CS 10, adc poll on CS 9, adc poll on CS 10.

Note that each wakeup protocol is 800 us and adc polling delay took 13 ms -- now takes 8 ms

Also there was a chip indexing issue that caused incorrect packaging of data from the bms driver.